### PR TITLE
CI: Add GitHub Actions workflow for Jest tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Run Jest Tests
+
+on:
+  pull_request:
+    branches:
+      - main # Or your default branch, e.g., master
+      - master # Adding master as a common default branch name
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x] # Test on common Node versions
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4 # Updated to v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4 # Updated to v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm' # Or 'yarn' if you use yarn
+
+      - name: Install dependencies
+        run: npm ci # Or 'yarn install --frozen-lockfile'
+
+      - name: Run tests
+        run: npm test # This assumes you have a "test": "jest" script in your package.json


### PR DESCRIPTION
Introduces a GitHub Actions workflow to automatically run Jest tests on pull requests and pushes to the main/master branches.

The workflow performs the following steps:
- Checks out the repository code.
- Sets up multiple Node.js versions (16.x, 18.x, 20.x) for testing.
- Installs dependencies using `npm ci` for reliable builds.
- Runs the test suite using `npm test` (assuming 'jest' is the command for the test script in package.json).