### PR TITLE
Fix: Attempt to resolve test failures in utils.test.mjs

### DIFF
--- a/js/utils.mjs
+++ b/js/utils.mjs
@@ -39,6 +39,13 @@ export const downloadBlob = (data, fileName) => {
 };
 
 export const hexToRgb = hex => {
+    if (!hex) return null;
+    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+    const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+        return r + r + g + g + b + b;
+    });
+
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result ? { r: parseInt(result[1], 16), g: parseInt(result[2], 16), b: parseInt(result[3], 16) } : null;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,6 +2589,7 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.2.tgz",
       "integrity": "sha512-lwMpe7hZ81e2PpHj+4nowAzSkC0p8ftRfzC+qEjav9p5ElCs6LAce3y46iLwMS27oL9+/KQe55gUvUDwrlDeJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.0.2",
         "@jest/environment-jsdom-abstract": "30.0.2",


### PR DESCRIPTION
This commit includes several changes aimed at fixing test failures:

1.  **Fixed `hexToRgb` function**: Modified `js/utils.mjs` to correctly handle 3-digit shorthand hex color codes (e.g., `#ABC`). The original implementation only supported 6-digit codes.

2.  **Addressed Jest global errors**: Imported `describe`, `test`, `expect`, `beforeEach`, `afterEach`, and `jest` from `@jest/globals` in `tests/utils.test.mjs` to resolve `ReferenceError: jest is not defined`.

3.  **Installed `jest-environment-jsdom`**: Added `jest-environment-jsdom` as a dev dependency as it's no longer shipped with Jest by default, which was causing an initial test environment error.

4.  **Attempted to mock `domElements.mjs` for DOM utility tests**: The primary remaining issue lies in tests for `showLoader` and `hideLoader` within `tests/utils.test.mjs`. These functions in `js/utils.mjs` import `loaderOverlay` and `loaderText` directly from `js/domElements.mjs`. In the test environment, these imported values are consistently `null` or `undefined`, causing the utility functions to fail to interact with the DOM as expected by the tests (which try to assert calls on mocked versions of these elements).

    Several advanced Jest ESM mocking techniques were attempted to make `js/utils.mjs` use mocked versions of `loaderOverlay` and `loaderText`:
    *   Using `jest.mock('../js/domElements.mjs', factory)` with various factory implementations.
    *   Defining mock objects externally and returning them from the factory.
    *   Employing dynamic `await import('../js/utils.mjs')` for the utility functions within `beforeAll` blocks to ensure mocks were established prior to the module's code execution.
    *   Removing all static imports of `js/utils.mjs` to prevent premature loading before mocks could take effect.

    Despite these efforts, `js/utils.mjs` continued to log errors indicating that `loaderOverlay` and `loaderText` were not found (i.e., they were `null`/`undefined` at the point of import within `utils.mjs`). This suggests a persistent difficulty in ensuring the Jest mock for `domElements.mjs` correctly intercepts the import when `utils.mjs` is loaded, even with dynamic imports and other ESM-specific strategies.

    The tests for `hexToRgb` and `hasRtl` are passing. The tests for `downloadBlob` are also passing as its DOM interactions (creating an anchor element) are more straightforward to mock using `jest.spyOn(document, 'createElement')`.

    The current state of `tests/utils.test.mjs` reflects the latest attempt using dynamic imports for all functions from `utils.mjs` and a standard `jest.mock` setup for `domElements.mjs`.

    Further investigation would likely require deeper diving into Jest's ESM module caching and resolution in this specific project's context or considering refactoring `js/utils.mjs` to allow dependency injection for easier testing of `showLoader` and `hideLoader`.