### PR TITLE
Fix: Include and register fontkit for PDF-Lib

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Offline PDF Editor</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+    <script src="https://unpkg.com/@pdf-lib/fontkit/dist/fontkit.umd.js"></script>
     <script src="https://unpkg.com/pdf-lib/dist/pdf-lib.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.15.0/Sortable.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/js/app.js
+++ b/js/app.js
@@ -9,6 +9,11 @@ import { parsePdfCustomData } from './pdfMetadata.js'; // Import the new functio
 
 // Removed TypeScript type placeholders
 
+// Add this registration code
+if (window.PDFLib && window.fontkit) {
+  window.PDFLib.PDFDocument.registerFontkit(window.fontkit);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize the debug system with necessary DOM elements
     initDebugSystem({


### PR DESCRIPTION
This resolves an issue where PDF generation failed for text containing non-ASCII characters, specifically Hebrew, due to the missing `fontkit` dependency.

- Included `fontkit` via CDN in `index.html`.
- Registered `fontkit` with `pdf-lib` in `js/app.js`.

These changes ensure that custom fonts can be embedded, allowing Hebrew and other non-standard characters to be saved and printed correctly.