### PR TITLE
Fix: Resolve errors related to Hebrew font embedding in PDF printing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -67,13 +67,28 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (window.PDFLib && window.fontkit) {
             try {
-                // Use the imported PDFDocument object to be safe
-                PDFDocument.registerFontkit(window.fontkit);
-                logDebug("Successfully registered fontkit with PDFLib.");
-                fontkitRegistered = true;
+                // Explicitly use window.PDFLib.PDFDocument and check if registerFontkit exists
+                if (window.PDFLib.PDFDocument && typeof window.PDFLib.PDFDocument.registerFontkit === 'function') {
+                    window.PDFLib.PDFDocument.registerFontkit(window.fontkit);
+                    logDebug("Successfully registered fontkit with PDFLib using window.PDFLib.PDFDocument.");
+                    fontkitRegistered = true;
+                } else {
+                    const debugInfo = {
+                        hasPDFLib: !!window.PDFLib,
+                        hasFontkit: !!window.fontkit,
+                        hasPDFDocument: !!(window.PDFLib && window.PDFLib.PDFDocument),
+                        hasRegisterFontkitMethod: !!(window.PDFLib && window.PDFLib.PDFDocument && typeof window.PDFLib.PDFDocument.registerFontkit === 'function'),
+                        pdfDocumentKeys: (window.PDFLib && window.PDFLib.PDFDocument) ? Object.keys(window.PDFLib.PDFDocument) : "N/A"
+                    };
+                    console.error("window.PDFLib.PDFDocument.registerFontkit is not a function or PDFDocument is missing.", debugInfo);
+                    logDebug("registerFontkitOnce: window.PDFLib.PDFDocument.registerFontkit is not available as expected.", debugInfo);
+                    // Throw an error to indicate failure, which will be caught below
+                    throw new Error("Custom: PDFDocument.registerFontkit is not available on window.PDFLib.PDFDocument.");
+                }
             } catch (error) {
                 console.error("Error registering fontkit with PDFLib:", error);
-                logDebug("Error registering fontkit with PDFLib:", { error: error.message, stack: error.stack });
+                logDebug("Error registering fontkit with PDFLib (original or custom):", { error: error.message, stack: error.stack });
+                // Potentially re-throw or set a flag indicating failure if other parts of the app need to know
             }
         } else {
             console.error("PDFLib or fontkit not available for registration.");


### PR DESCRIPTION
This commit addresses a series of errors encountered when printing PDFs containing Hebrew text. The primary issue was the failure to correctly register `fontkit` with `pdf-lib`, leading to subsequent errors in embedding a custom Hebrew font and rendering Hebrew characters.

Changes include:
- Modified `registerFontkitOnce` in `js/app.js` to explicitly use `window.PDFLib.PDFDocument.registerFontkit` and added robust checks and detailed logging to diagnose its availability. This is to ensure that the `fontkit` registration is attempted correctly, even with potential inconsistencies from the CDN-loaded `pdf-lib`.

The expectation is that these changes will allow `fontkit` to be registered, the custom Hebrew font to be embedded, and Hebrew text to be rendered correctly in the print output, resolving the `PDFDocument2.registerFontkit`, `embedFont no fontkit`, and `WinAnsi cannot encode` errors.