### PR TITLE
Fix: Correct PDF.js worker file path and imports

### DIFF
--- a/js/pdfSetup.js
+++ b/js/pdfSetup.js
@@ -1,6 +1,5 @@
 // js/pdfSetup.js
-import * as pdfjsLib from 'pdfjs-dist/build/pdf.js';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry.js';
+import * as pdfjsLib from 'pdfjs-dist/build/pdf.mjs';
 
 import {
     PDFDocument as PDFLibDocument, // Renamed to avoid conflict with pdf.js's PDFDocument type if it were used
@@ -16,7 +15,7 @@ import {
 // Setup for PDF.js worker
 if (pdfjsLib && pdfjsLib.GlobalWorkerOptions) {
     // The worker is copied to the 'dist' folder by the build script
-    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.js';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.mjs';
 } else {
     console.error("pdfjsLib or GlobalWorkerOptions is not defined. This should not happen with direct imports.");
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -16,8 +16,8 @@ const versionFile = path.join(distDir, 'version.json');
 const packageJsonPath = path.resolve(projectRoot, 'package.json');
 // const tailwindInputCss = path.resolve(projectRoot, 'css/tailwind.css'); // Removed
 // const tailwindOutputCss = path.join(distDir, 'tailwind.css'); // Removed
-const pdfWorkerSource = path.resolve(projectRoot, 'node_modules/pdfjs-dist/build/pdf.worker.js');
-const pdfWorkerDest = path.join(distDir, 'pdf.worker.js');
+const pdfWorkerSource = path.resolve(projectRoot, 'node_modules/pdfjs-dist/build/pdf.worker.mjs');
+const pdfWorkerDest = path.join(distDir, 'pdf.worker.mjs');
 
 
 console.log('Entry point:', entryPoint);


### PR DESCRIPTION
- Updated build script to copy `pdf.worker.mjs` instead of `pdf.worker.js`.
- Updated PDF setup to use `pdf.worker.mjs` for `GlobalWorkerOptions.workerSrc`.
- Corrected `pdfjsLib` import in PDF setup to `pdfjs-dist/build/pdf.mjs`.
- Removed unused import of `pdf.worker.entry.js`.

These changes resolve the build failure caused by incorrect PDF.js worker file paths and esbuild resolution errors.