### PR TITLE
Fix: Correct pdf-lib import to resolve save error

### DIFF
--- a/js/pdfSetup.js
+++ b/js/pdfSetup.js
@@ -1,16 +1,6 @@
 // js/pdfSetup.js
 import * as pdfjsLib from 'pdfjs-dist/build/pdf.mjs';
-
-import {
-    PDFDocument as PDFLibDocument, // Renamed to avoid conflict with pdf.js's PDFDocument type if it were used
-    rgb,
-    StandardFonts,
-    TextAlignment,
-    PDFName,
-    PDFString,
-    PDFHexString,
-    grayscale
-} from 'pdf-lib';
+import * as pdfLib from 'pdf-lib';
 
 // Setup for PDF.js worker
 if (pdfjsLib && pdfjsLib.GlobalWorkerOptions) {
@@ -23,9 +13,9 @@ if (pdfjsLib && pdfjsLib.GlobalWorkerOptions) {
 // Export the pdfjsLib itself to be used by app.js
 export { pdfjsLib };
 
-// Export PDFLib objects (already imported and destructured)
-export {
-    PDFLibDocument as PDFDocument, // Export with the original intended name for use in app.js
+// Export PDFLib objects from the imported module
+export const {
+    PDFDocument,
     rgb,
     StandardFonts,
     TextAlignment,
@@ -33,9 +23,4 @@ export {
     PDFString,
     PDFHexString,
     grayscale,
-};
-
-// For window.showSaveFilePicker, it's typically checked for existence before use:
-// if (window.showSaveFilePicker) { /* ... */ }
-// JSDoc for window properties can be done in a central d.ts or by casting window to any
-// For the purpose of this conversion, direct usage with existence checks is standard for JS.
+} = pdfLib;


### PR DESCRIPTION
Changed the named import of PDFDocument from 'pdf-lib' to a namespace import (`import * as pdfLib from 'pdf-lib'`). This ensures that all necessary components of the library, including `registerFontkit`, are loaded correctly.

This resolves the 'PDFDocument.registerFontkit is not a function' error and the subsequent 'Failed to parse PDF document... No PDF header found' error, allowing users to save edited PDFs successfully.