### PR TITLE
Fix(app): Prevent pdf.js from corrupting PDF data on load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', () => {
          utils.showLoader('Rendering PDF...');
          pdfBytes = bytes;
          const pdfDocInstance = await PDFDocument.load(bytes, { ignoreEncryption: true }); // pdf-lib instance
-         pdfDoc = await pdfjsLib.getDocument({ data: bytes }).promise; // pdf.js instance
+         pdfDoc = await pdfjsLib.getDocument({ data: bytes.slice().buffer }).promise; // pdf.js instance
 
          textObjects = [];
          redactionAreas = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "esbuild": "^0.25.5",
         "jest": "^29.0.0",
-        "jest-environment-jsdom": "^30.0.2"
+        "jest-environment-jsdom": "^30.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1191,14 +1191,14 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.2.tgz",
-      "integrity": "sha512-8aMoEzGdUuJeQl71BUACkys1ZEX437AF376VBqdYXsGFd4l3F1SdTjFHmNq8vF0Rp+CYhUyxa0kRAzXbBaVzfQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.4.tgz",
+      "integrity": "sha512-pUKfqgr5Nki9kZ/3iV+ubDsvtPq0a0oNL6zqkKLM1tPQI8FBJeuWskvW1kzc5pOvqlgpzumYZveJ4bxhANY0hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/fake-timers": "30.0.2",
+        "@jest/environment": "30.0.4",
+        "@jest/fake-timers": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/jsdom": "^21.1.7",
         "@types/node": "*",
@@ -1219,13 +1219,13 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.2.tgz",
-      "integrity": "sha512-hRLhZRJNxBiOhxIKSq2UkrlhMt3/zVFQOAi5lvS8T9I03+kxsbflwHJEF+eXEYXCrRGRhHwECT7CDk6DyngsRA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.4.tgz",
+      "integrity": "sha512-5NT+sr7ZOb8wW7C4r7wOKnRQ8zmRWQT2gW4j73IXAKp5/PX1Z8MCStBLQDYfIG3n1Sw0NRfYGdp0iIPVooBAFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.0.2",
+        "@jest/fake-timers": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "jest-mock": "30.0.2"
@@ -1235,9 +1235,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.2.tgz",
-      "integrity": "sha512-jfx0Xg7l0gmphTY9UKm5RtH12BlLYj/2Plj6wXjVW5Era4FZKfXeIvwC67WX+4q8UCFxYS20IgnMcFBcEU0DtA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.4.tgz",
+      "integrity": "sha512-qZ7nxOcL5+gwBO6LErvwVy5k06VsX/deqo2XnVUSTV0TNC9lrg8FC3dARbi+5lmrr5VyX5drragK+xLcOjvjYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
-      "version": "0.34.37",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-      "integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
+      "version": "0.34.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
+      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1315,9 +1315,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -1385,9 +1385,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2060,9 +2060,9 @@
       "license": "MIT"
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2574,9 +2574,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3466,14 +3466,14 @@
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.2.tgz",
-      "integrity": "sha512-lwMpe7hZ81e2PpHj+4nowAzSkC0p8ftRfzC+qEjav9p5ElCs6LAce3y46iLwMS27oL9+/KQe55gUvUDwrlDeJQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.4.tgz",
+      "integrity": "sha512-9WmS3oyCLFgs6DUJSoMpVb+AbH62Y2Xecw3XClbRgj6/Z+VjNeSLjrhBgVvTZ40njZTWeDHv8unp+6M/z8ADDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/environment-jsdom-abstract": "30.0.2",
+        "@jest/environment": "30.0.4",
+        "@jest/environment-jsdom-abstract": "30.0.4",
         "@types/jsdom": "^21.1.7",
         "@types/node": "*",
         "jsdom": "^26.1.0"
@@ -3491,13 +3491,13 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.2.tgz",
-      "integrity": "sha512-hRLhZRJNxBiOhxIKSq2UkrlhMt3/zVFQOAi5lvS8T9I03+kxsbflwHJEF+eXEYXCrRGRhHwECT7CDk6DyngsRA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.4.tgz",
+      "integrity": "sha512-5NT+sr7ZOb8wW7C4r7wOKnRQ8zmRWQT2gW4j73IXAKp5/PX1Z8MCStBLQDYfIG3n1Sw0NRfYGdp0iIPVooBAFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.0.2",
+        "@jest/fake-timers": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "jest-mock": "30.0.2"
@@ -3507,9 +3507,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.2.tgz",
-      "integrity": "sha512-jfx0Xg7l0gmphTY9UKm5RtH12BlLYj/2Plj6wXjVW5Era4FZKfXeIvwC67WX+4q8UCFxYS20IgnMcFBcEU0DtA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.4.tgz",
+      "integrity": "sha512-qZ7nxOcL5+gwBO6LErvwVy5k06VsX/deqo2XnVUSTV0TNC9lrg8FC3dARbi+5lmrr5VyX5drragK+xLcOjvjYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3557,9 +3557,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-      "version": "0.34.37",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-      "integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
+      "version": "0.34.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
+      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3587,9 +3587,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -3657,9 +3657,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "esbuild": "^0.25.5",
     "jest": "^29.0.0",
-    "jest-environment-jsdom": "^30.0.2"
+    "jest-environment-jsdom": "^30.0.4"
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",


### PR DESCRIPTION
The `pdfjsLib.getDocument()` function was consuming or invalidating the `pdfBytes` array, which caused the `performStandardSave` function to fail with a "No PDF header found" error.

This fix prevents this by creating a shallow copy of the `pdfBytes` array before passing it to `pdfjsLib.getDocument()`, ensuring that the original `pdfBytes` array is not modified.